### PR TITLE
Use an executor service to avoid rapid thread creation

### DIFF
--- a/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -294,6 +294,7 @@ public abstract class Pet implements Listener {
         for (Item i : items)
             i.remove();
         items.clear();
+        pathUpdater.shutdown();
         try {
             HandlerList.unregisterAll(this);
             HandlerList.unregisterAll(listener);


### PR DESCRIPTION
For every active pet, a new thread is created every 6 ticks.  Thread creation is a [highly expensive operation](http://stackoverflow.com/questions/5483047/why-is-creating-a-thread-said-to-be-expensive), and will put more load on the server.

Fortunately we can get around this using a Java ExecutorService, which will reuse a single thread to run a task over and over again until we no longer need it.