### PR TITLE
Do not shut down if cannot connect to MySQL

### DIFF
--- a/src/main/java/be/isach/ultracosmetics/Core.java
+++ b/src/main/java/be/isach/ultracosmetics/Core.java
@@ -627,12 +627,6 @@ public class Core extends JavaPlugin {
                         Bukkit.getLogger().info("");
                         Bukkit.getConsoleSender().sendMessage("§c§lError:");
                         e.printStackTrace();
-                        Bukkit.getLogger().info("");
-                        Bukkit.getLogger().info("");
-                        Bukkit.getConsoleSender().sendMessage("§c§lServer shutting down, please check the MySQL info!");
-                        Bukkit.getLogger().info("");
-                        Bukkit.getLogger().info("");
-                        Bukkit.shutdown();
 
                     }
                 }


### PR DESCRIPTION
If MySQL goes down it should not shutdown the server. This can cause server to unexpectedly shut down if it cannot connect to MySQL for one attempt.