### PR TITLE
Prevent BlackHole gadget spamming broadcast messages

### DIFF
--- a/src/main/java/be/isach/ultracosmetics/cosmetics/gadgets/GadgetBlackHole.java
+++ b/src/main/java/be/isach/ultracosmetics/cosmetics/gadgets/GadgetBlackHole.java
@@ -56,8 +56,6 @@ public class GadgetBlackHole extends Gadget {
     void onUpdate() {
         EntityPlayer entityHuman = ((CraftPlayer)getPlayer()).getHandle();
 
-        Bukkit.broadcastMessage(entityHuman.bd + "");
-        Bukkit.broadcastMessage(entityHuman.be + "");
         if (i != null && i.isOnGround()) {
             int strands = 6;
             int particles = 25;


### PR DESCRIPTION
It looks like some debugging messages have been left in the source for the BlackHole gadget, this pull request removes them.