### PR TITLE
Adjusted pet names

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
+++ b/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
@@ -253,6 +253,7 @@ public class UltraCosmetics extends JavaPlugin {
         RegisteredServiceProvider<Economy> economyProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
         if (economyProvider != null) {
             economy = economyProvider.getProvider();
+            UltraCosmeticsData.get().setUsingVaultEconomy(true);
         }
 
         vaultLoaded = true;

--- a/core/src/main/java/be/isach/ultracosmetics/UltraCosmeticsData.java
+++ b/core/src/main/java/be/isach/ultracosmetics/UltraCosmeticsData.java
@@ -4,7 +4,6 @@ import be.isach.ultracosmetics.config.SettingsManager;
 import be.isach.ultracosmetics.util.ServerVersion;
 import be.isach.ultracosmetics.version.VersionManager;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 
 /**
  * This class is only for cleaning main class a bit.
@@ -56,14 +55,14 @@ public class UltraCosmeticsData {
     private boolean moneyTreasureLoot;
 
     /**
+     * If a Vault economy is being used.
+     */
+    private boolean usingVaultEconomy;
+
+    /**
      * Determines if Gadget Cooldown should be shown in action bar.
      */
     private boolean cooldownInBar;
-
-    /**
-     * Determines if Pet Renaming required Money.
-     */
-    private boolean petRenameMoney;
 
     /**
      * Should the GUI close after Cosmetic Selection?
@@ -196,10 +195,6 @@ public class UltraCosmeticsData {
         return moneyTreasureLoot;
     }
 
-    public boolean isPetRenameMoney() {
-        return petRenameMoney;
-    }
-
     public boolean arePlaceholdersColored() {
         return placeHolderColor;
     }
@@ -234,5 +229,13 @@ public class UltraCosmeticsData {
 
     public void setServerVersion(ServerVersion serverVersion) {
         this.serverVersion = serverVersion;
+    }
+
+    public void setUsingVaultEconomy(boolean usingVaultEconomy) {
+        this.usingVaultEconomy = usingVaultEconomy;
+    }
+
+    public boolean isUsingVaultEconomy() {
+        return this.usingVaultEconomy;
     }
 }

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -9,12 +9,10 @@ import be.isach.ultracosmetics.cosmetics.Updatable;
 import be.isach.ultracosmetics.cosmetics.type.PetType;
 import be.isach.ultracosmetics.player.UltraPlayer;
 import be.isach.ultracosmetics.util.EntitySpawningManager;
-import be.isach.ultracosmetics.util.ServerVersion;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Ageable;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -34,14 +32,13 @@ import java.util.concurrent.Executors;
  * @since 03-08-2015
  */
 public abstract class Pet extends Cosmetic<PetType> implements Updatable {
-
     /**
      * List of items popping out from Pet.
      */
     public ArrayList<Item> items = new ArrayList<>();
 
     /**
-     * Armor stand which is the name of the pet.
+     * ArmorStand for nametags. Most pets don't use this.
      */
     public ArmorStand armorStand;
 
@@ -93,44 +90,15 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
         }
 
         // TODO Test other versions to see if we can get rid of ArmorStands.
-        if (UltraCosmeticsData.get().getServerVersion() == ServerVersion.v1_11_R1) {
-            getEntity().setCustomNameVisible(true);
-            getEntity().setCustomName(getType().getEntityName(getPlayer()));
+        getEntity().setCustomNameVisible(true);
+        getEntity().setCustomName(getType().getEntityName(getPlayer()));
 
-            if (getOwner().getPetName(getType()) != null) {
-                getEntity().setCustomName(getOwner().getPetName(getType()));
-            }
-        } else {
-            armorStand = (ArmorStand) this.getPlayer().getWorld().spawnEntity(this.getPlayer().getLocation(), EntityType.ARMOR_STAND);
-            armorStand.setVisible(false);
-            armorStand.setSmall(true);
-            armorStand.setGravity(false);
-            armorStand.setCustomName(getType().getEntityName(getPlayer()));
-            armorStand.setCustomNameVisible(true);
-            armorStand.setRemoveWhenFarAway(true);
-            getUltraCosmetics().getArmorStandManager().makeUcStand(armorStand);
-
-            if (getOwner().getPetName(getType()) != null) {
-                armorStand.setCustomName(getOwner().getPetName(getType()));
-            }
+        if (getOwner().getPetName(getType()) != null) {
+            getEntity().setCustomName(getOwner().getPetName(getType()));
         }
 
         ((LivingEntity) entity).setRemoveWhenFarAway(false);
         UltraCosmeticsData.get().getVersionManager().getPathfinderUtil().removePathFinders(entity);
-        // this.entity.setPassenger(armorStand);
-
-        if (getType() == PetType.WITHER) {
-            this.entity.setCustomName(getType().getEntityName(getPlayer()));
-            this.entity.setCustomNameVisible(true);
-
-            if (getOwner().getPetName(getType()) != null) {
-                this.entity.setCustomName(getOwner().getPetName(getType()));
-            }
-
-            if (armorStand != null) {
-                armorStand.remove();
-            }
-        }
 
         this.entity.setMetadata("Pet", new FixedMetadataValue(getUltraCosmetics(), "UltraCosmetics"));
     }
@@ -181,11 +149,6 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
                 items.clear();
                 clear();
                 return;
-            }
-
-            if (armorStand != null
-                    && getType() != PetType.WITHER) {
-                armorStand.teleport(getEntity().getLocation().add(0, -0.7, 0));
             }
         } catch (NullPointerException exc) {
             exc.printStackTrace();

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -88,8 +88,7 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
             }
             ((Ageable) entity).setAgeLock(true);
         }
-
-        // TODO Test other versions to see if we can get rid of ArmorStands.
+        
         getEntity().setCustomNameVisible(true);
         getEntity().setCustomName(getType().getEntityName(getPlayer()));
 

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -11,13 +11,17 @@ import be.isach.ultracosmetics.player.UltraPlayer;
 import be.isach.ultracosmetics.util.EntitySpawningManager;
 import be.isach.ultracosmetics.util.ServerVersion;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Ageable;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
@@ -85,29 +89,31 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
             } else {
                 ((Ageable) entity).setAdult();
             }
-
             ((Ageable) entity).setAgeLock(true);
         }
 
+        String customName = getOwner().getPetName(getType());
+
+        // TODO Test other versions to see if we can get rid of ArmorStands.
         if (UltraCosmeticsData.get().getServerVersion() == ServerVersion.v1_11_R1) {
             getEntity().setCustomNameVisible(true);
-            getEntity().setCustomName(getType().getEntityName(getPlayer()));
+            getEntity().setCustomName(customName == null ? getType().getEntityName(getPlayer()) : customName);
 
             if (getOwner().getPetName(getType()) != null) {
-                getEntity().setCustomName(getOwner().getPetName(getType()));
+                getEntity().setCustomName(customName == null ? getOwner().getPetName(getType()) : customName);
             }
         } else {
             armorStand = (ArmorStand) this.getPlayer().getWorld().spawnEntity(this.getPlayer().getLocation(), EntityType.ARMOR_STAND);
             armorStand.setVisible(false);
             armorStand.setSmall(true);
             armorStand.setGravity(false);
-            armorStand.setCustomName(getType().getEntityName(getPlayer()));
+            armorStand.setCustomName(customName == null ? getType().getEntityName(getPlayer()) : customName);
             armorStand.setCustomNameVisible(true);
             armorStand.setRemoveWhenFarAway(true);
             getUltraCosmetics().getArmorStandManager().makeUcStand(armorStand);
 
             if (getOwner().getPetName(getType()) != null) {
-                armorStand.setCustomName(getOwner().getPetName(getType()));
+                armorStand.setCustomName(customName == null ? getOwner().getPetName(getType()) : customName);
             }
         }
 
@@ -116,11 +122,11 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
         // this.entity.setPassenger(armorStand);
 
         if (getType() == PetType.WITHER) {
-            this.entity.setCustomName(getType().getEntityName(getPlayer()));
+            this.entity.setCustomName(customName == null ? getType().getEntityName(getPlayer()) : customName);
             this.entity.setCustomNameVisible(true);
 
             if (getOwner().getPetName(getType()) != null) {
-                this.entity.setCustomName(getOwner().getPetName(getType()));
+                this.entity.setCustomName(customName == null ? getOwner().getPetName(getType()) : customName);
             }
 
             if (armorStand != null) {

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/pets/Pet.java
@@ -92,28 +92,26 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
             ((Ageable) entity).setAgeLock(true);
         }
 
-        String customName = getOwner().getPetName(getType());
-
         // TODO Test other versions to see if we can get rid of ArmorStands.
         if (UltraCosmeticsData.get().getServerVersion() == ServerVersion.v1_11_R1) {
             getEntity().setCustomNameVisible(true);
-            getEntity().setCustomName(customName == null ? getType().getEntityName(getPlayer()) : customName);
+            getEntity().setCustomName(getType().getEntityName(getPlayer()));
 
             if (getOwner().getPetName(getType()) != null) {
-                getEntity().setCustomName(customName == null ? getOwner().getPetName(getType()) : customName);
+                getEntity().setCustomName(getOwner().getPetName(getType()));
             }
         } else {
             armorStand = (ArmorStand) this.getPlayer().getWorld().spawnEntity(this.getPlayer().getLocation(), EntityType.ARMOR_STAND);
             armorStand.setVisible(false);
             armorStand.setSmall(true);
             armorStand.setGravity(false);
-            armorStand.setCustomName(customName == null ? getType().getEntityName(getPlayer()) : customName);
+            armorStand.setCustomName(getType().getEntityName(getPlayer()));
             armorStand.setCustomNameVisible(true);
             armorStand.setRemoveWhenFarAway(true);
             getUltraCosmetics().getArmorStandManager().makeUcStand(armorStand);
 
             if (getOwner().getPetName(getType()) != null) {
-                armorStand.setCustomName(customName == null ? getOwner().getPetName(getType()) : customName);
+                armorStand.setCustomName(getOwner().getPetName(getType()));
             }
         }
 
@@ -122,11 +120,11 @@ public abstract class Pet extends Cosmetic<PetType> implements Updatable {
         // this.entity.setPassenger(armorStand);
 
         if (getType() == PetType.WITHER) {
-            this.entity.setCustomName(customName == null ? getType().getEntityName(getPlayer()) : customName);
+            this.entity.setCustomName(getType().getEntityName(getPlayer()));
             this.entity.setCustomNameVisible(true);
 
             if (getOwner().getPetName(getType()) != null) {
-                this.entity.setCustomName(customName == null ? getOwner().getPetName(getType()) : customName);
+                this.entity.setCustomName(getOwner().getPetName(getType()));
             }
 
             if (armorStand != null) {

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/suits/Suit.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/suits/Suit.java
@@ -48,7 +48,7 @@ public abstract class Suit extends Cosmetic<SuitType> implements Updatable {
             return;
         }
         ItemStack drop = event.getItemDrop().getItemStack();
-        if (getPlayer() == null && event.getPlayer().equals(getPlayer()) && drop.hasItemMeta() && drop.getItemMeta().hasDisplayName() && drop.getItemMeta().getDisplayName().equals(itemStack.getItemMeta().getDisplayName())) {
+        if (event.getPlayer().equals(getPlayer()) && drop.hasItemMeta() && drop.getItemMeta().hasDisplayName() && drop.getItemMeta().getDisplayName().equals(itemStack.getItemMeta().getDisplayName())) {
             event.getItemDrop().remove();
             if (SettingsManager.getConfig().getBoolean("Remove-Gadget-With-Drop")) {
                 clear();

--- a/core/src/main/java/be/isach/ultracosmetics/menu/menus/MenuPets.java
+++ b/core/src/main/java/be/isach/ultracosmetics/menu/menus/MenuPets.java
@@ -51,22 +51,22 @@ public class MenuPets extends CosmeticMenu<PetType> {
                     if (player.getCurrentPet() != null) {
                         stack = ItemFactory.create(ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getItemType(), ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getData(), MessageManager.getMessage("Rename-Pet").replace("%petname%", player.getCurrentPet().getType().getName()));
                         run = data -> {
-                            renamePet(player);
                             player.getBukkitPlayer().closeInventory();
+                            renamePet(player);
                         };
                     } else {
                         stack = ItemFactory.create(ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getItemType(), ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getData(), MessageManager.getMessage("Active-Pet-Needed"));
                         run = data -> {
-                            player.getBukkitPlayer().sendMessage(MessageManager.getMessage("Active-Pet-Needed"));
                             player.getBukkitPlayer().closeInventory();
+                            player.getBukkitPlayer().sendMessage(MessageManager.getMessage("Active-Pet-Needed"));
                         };
                     }
                 }
             } else if (player.getCurrentPet() != null) {
                 stack = ItemFactory.create(ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getItemType(), ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getData(), MessageManager.getMessage("Rename-Pet").replace("%petname%", player.getCurrentPet().getType().getName()));
                 run = data -> {
-                  renamePet(player);
                     player.getBukkitPlayer().closeInventory();
+                    renamePet(player);
                 };
             } else {
                 stack = ItemFactory.create(ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getItemType(), ItemFactory.createFromConfig("Categories.Rename-Pet-Item").getData(), MessageManager.getMessage("Active-Pet-Needed"));
@@ -85,10 +85,10 @@ public class MenuPets extends CosmeticMenu<PetType> {
             if (event.getSlot() == AAnvilGUI.AnvilSlot.OUTPUT) {
                 event.setWillClose(true);
                 event.setWillDestroy(true);
-                if (event.getName() == null) {
+                if (event.getName() == null || event.getName().equals("")) {
                     return;
                 }
-                if (SettingsManager.getConfig().getBoolean("Pets-Rename.Requires-Money.Enabled") && UltraCosmeticsData.get().isPetRenameMoney()) {
+                if (SettingsManager.getConfig().getBoolean("Pets-Rename.Requires-Money.Enabled") && UltraCosmeticsData.get().isUsingVaultEconomy()) {
                     buyRenamePet(p, ChatColor.translateAlternateColorCodes('&', event.getName().replaceAll("[^A-Za-z0-9 &&[^&]]", "").replace(" ", "")));
                 } else {
                     if (ultraPlayer.getCurrentPet().getType() == PetType.WITHER || UltraCosmeticsData.get().getServerVersion() == ServerVersion.v1_11_R1) {
@@ -103,7 +103,7 @@ public class MenuPets extends CosmeticMenu<PetType> {
                 event.setWillDestroy(false);
             }
         });
-        gui.setSlot(AAnvilGUI.AnvilSlot.INPUT_LEFT, ItemFactory.create(Material.PAPER, (byte) 0x0, ""));
+        gui.setSlot(AAnvilGUI.AnvilSlot.INPUT_LEFT, ItemFactory.create(Material.NAME_TAG, (byte) 0x0, ""));
         gui.open();
     }
 
@@ -112,6 +112,7 @@ public class MenuPets extends CosmeticMenu<PetType> {
     }
 
     private void buyRenamePet(final Player p, final String name) {
+        // TODO Add InventoryClick Listener for this.
         p.closeInventory();
         Inventory inventory = Bukkit.createInventory(null, 54, MessageManager.getMessage("Menus.Rename-Pet"));
         for (int i = 27; i < 30; i++) {
@@ -123,9 +124,9 @@ public class MenuPets extends CosmeticMenu<PetType> {
             inventory.setItem(i + 18 + 6, ItemFactory.create(Material.REDSTONE_BLOCK, (byte) 0x0, MessageManager.getMessage("Cancel")));
         }
         inventory.setItem(13, ItemFactory.create(Material.NAME_TAG, (byte) 0x0, MessageManager.getMessage("Rename-Pet-Purchase")
-                .replace("%price%", "" + SettingsManager.getConfig().get("Pets-Rename.Requires-Money.Price")).replace("%name%", name)));
+                .replace("%price%", "" + SettingsManager.getConfig().getString("Pets-Rename.Requires-Money.Price")).replace("%name%", name)));
         ItemFactory.fillInventory(inventory);
-        p.openInventory(inventory);
+        Bukkit.getScheduler().runTaskLater(ultraCosmetics, () -> p.openInventory(inventory), 5);
     }
 
     @Override

--- a/core/src/main/java/be/isach/ultracosmetics/menu/menus/MenuPets.java
+++ b/core/src/main/java/be/isach/ultracosmetics/menu/menus/MenuPets.java
@@ -12,9 +12,7 @@ import be.isach.ultracosmetics.menu.CosmeticMenu;
 import be.isach.ultracosmetics.player.UltraPlayer;
 import be.isach.ultracosmetics.util.ItemFactory;
 import be.isach.ultracosmetics.util.PurchaseData;
-import be.isach.ultracosmetics.util.ServerVersion;
 import be.isach.ultracosmetics.version.AAnvilGUI;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -89,7 +87,7 @@ public class MenuPets extends CosmeticMenu<PetType> {
                 if (SettingsManager.getConfig().getBoolean("Pets-Rename.Requires-Money.Enabled") && UltraCosmeticsData.get().getPlugin().isVaultLoaded()) {
                     event.setWillClose(false);
                     event.setWillDestroy(false);
-                    buyRenamePet(ultraPlayer, ChatColor.translateAlternateColorCodes('&', event.getName().replaceAll("[^A-Za-z0-9 &&[^&]]", "").replace(" ", "")));
+                    buyRenamePet(ultraPlayer, event.getName());
                 } else {
                     ultraPlayer.setPetName(ultraPlayer.getCurrentPet().getType(), event.getName());
                 }
@@ -113,9 +111,7 @@ public class MenuPets extends CosmeticMenu<PetType> {
         PurchaseData purchaseData = new PurchaseData();
         purchaseData.setPrice(SettingsManager.getConfig().getInt("Pets-Rename.Requires-Money.Price"));
         purchaseData.setShowcaseItem(showcaseItem);
-        purchaseData.setOnPurchase(() -> {
-            ultraPlayer.setPetName(ultraPlayer.getCurrentPet().getType(), name);
-        });
+        purchaseData.setOnPurchase(() -> ultraPlayer.setPetName(ultraPlayer.getCurrentPet().getType(), name));
 
         MenuPurchase menu = new MenuPurchase(getUltraCosmetics(), MessageManager.getMessage("Menus.Rename-Pet"), purchaseData);
         menu.open(ultraPlayer);
@@ -126,7 +122,7 @@ public class MenuPets extends CosmeticMenu<PetType> {
         if(player.getPetName(cosmeticType) != null) {
             ItemStack item = itemStack.clone();
             ItemMeta itemMeta = itemStack.getItemMeta();
-            itemMeta.setDisplayName(itemMeta.getDisplayName() + " r7(" + player.getPetName(cosmeticType) + ")");
+            itemMeta.setDisplayName(itemMeta.getDisplayName() + ChatColor.GRAY + " (" + player.getPetName(cosmeticType) + ")");
             item.setItemMeta(itemMeta);
             return item;
         }

--- a/core/src/main/java/be/isach/ultracosmetics/player/UltraPlayer.java
+++ b/core/src/main/java/be/isach/ultracosmetics/player/UltraPlayer.java
@@ -22,7 +22,6 @@ import be.isach.ultracosmetics.run.FallDamageManager;
 import be.isach.ultracosmetics.treasurechests.TreasureChest;
 import be.isach.ultracosmetics.util.CacheValue;
 import be.isach.ultracosmetics.util.ItemFactory;
-import be.isach.ultracosmetics.util.ServerVersion;
 import me.libraryaddict.disguise.DisguiseAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -446,10 +445,10 @@ public class UltraPlayer {
     public void setPetName(PetType petType, String name) {
         name = ChatColor.translateAlternateColorCodes('&', name.replaceAll("[^A-Za-z0-9 &&[^&]]", "").replace(" ", ""));
         if (currentPet != null) {
-            if (currentPet.getType() == PetType.WITHER || UltraCosmeticsData.get().getServerVersion() == ServerVersion.v1_11_R1) {
-                currentPet.entity.setCustomName(name);
-            } else {
+            if (currentPet.armorStand != null) {
                 currentPet.armorStand.setCustomName(name);
+            } else {
+                currentPet.getEntity().setCustomName(name);
             }
         }
         if (UltraCosmeticsData.get().usingFileStorage()) {
@@ -473,7 +472,6 @@ public class UltraPlayer {
                 if (ultraCosmetics.getMySqlConnectionManager().getSqlUtils().getPetName(getMySqlIndex(), petType.getConfigName()).equalsIgnoreCase("Unknown")) {
                     return null;
                 }
-
                 return ultraCosmetics.getMySqlConnectionManager().getSqlUtils().getPetName(getMySqlIndex(), petType.getConfigName());
             }
         } catch (NullPointerException e) {


### PR DESCRIPTION
All pets but Pumpling now use custom names instead of ArmorStands. An ArmorStand is required for Pumpling as it's invisible making its custom name not show.