### PR TITLE
Add reload command

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -39,7 +39,8 @@ public class SubCommandReload extends SubCommand {
 			uc.getPlayerManager().getUltraPlayer(pl.getBukkitPlayer()).removeMenuItem();
 
 			uc.getPlayerManager().getUltraPlayer(pl.getBukkitPlayer()).giveMenuItem();
-			uc.getPlayerManager().getUltraPlayer(pl.getBukkitPlayer()).updateInventory();
+
+			pl.getBukkitPlayer().updateInventory();
 		}
 		sender.sendMessage(ChatColor.GREEN + "Plugin has been loaded successfully.");
 	}

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -27,17 +27,19 @@ public class SubCommandReload extends SubCommand {
 	}
 
 	private void common(CommandSender sender, String... args) {
+		SettingsManager.getConfig().save(uc.getFile());
+		SettingsManager.getConfig().load(uc.getFile());
 		SettingsManager.getConfig().loadConfiguration(uc.getFile());
 
 		for (be.isach.ultracosmetics.player.UltraPlayer pl : uc.getPlayerManager().getUltraPlayers()) {
-			if (pl.getInventory().getTitle().equalsIgnoreCase(uc.getMenus().getMainMenu().getName())) {
-				pl.closeInventory();
+			if (pl.getPlayer().getInventory().getTitle().equalsIgnoreCase(SettingsManager.getConfig().getString("Menu-Item.Displayname"))) {
+				pl.getPlayer().closeInventory();
 				//sender.sendMessage(ChatColor.RED + "The cosmetics menu has been closed, because reloading the plugin.");
 			}
-			uc.getPlayerManager().getUltraPlayer(pl).removeMenuItem();
+			uc.getPlayerManager().getUltraPlayer(pl.getPlayer()).removeMenuItem();
 
-			uc.getPlayerManager().getUltraPlayer(pl).giveMenuItem();
-			uc.getPlayerManager().getUltraPlayer(pl).updateInventory();
+			uc.getPlayerManager().getUltraPlayer(pl.getPlayer()).giveMenuItem();
+			uc.getPlayerManager().getUltraPlayer(pl.getPlayer()).updateInventory();
 		}
 		sender.sendMessage(ChatColor.GREEN + "Plugin has been loaded successfully.");
 	}

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -32,14 +32,14 @@ public class SubCommandReload extends SubCommand {
 		SettingsManager.getConfig().loadConfiguration(uc.getFile());
 
 		for (be.isach.ultracosmetics.player.UltraPlayer pl : uc.getPlayerManager().getUltraPlayers()) {
-			if (pl.getPlayer().getInventory().getTitle().equalsIgnoreCase(SettingsManager.getConfig().getString("Menu-Item.Displayname"))) {
-				pl.getPlayer().closeInventory();
+			if (pl.getBukkitPlayer().getInventory().getTitle().equalsIgnoreCase(SettingsManager.getConfig().getString("Menu-Item.Displayname"))) {
+				pl.getBukkitPlayer().closeInventory();
 				//sender.sendMessage(ChatColor.RED + "The cosmetics menu has been closed, because reloading the plugin.");
 			}
-			uc.getPlayerManager().getUltraPlayer(pl.getPlayer()).removeMenuItem();
+			uc.getPlayerManager().getUltraPlayer(pl.getBukkitPlayer()).removeMenuItem();
 
-			uc.getPlayerManager().getUltraPlayer(pl.getPlayer()).giveMenuItem();
-			uc.getPlayerManager().getUltraPlayer(pl.getPlayer()).updateInventory();
+			uc.getPlayerManager().getUltraPlayer(pl.getBukkitPlayer()).giveMenuItem();
+			uc.getPlayerManager().getUltraPlayer(pl.getBukkitPlayer()).updateInventory();
 		}
 		sender.sendMessage(ChatColor.GREEN + "Plugin has been loaded successfully.");
 	}

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -3,7 +3,6 @@ package be.isach.ultracosmetics.command.subcommands;
 import be.isach.ultracosmetics.config.SettingsManager;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.command.SubCommand;
-import java.io.IOException;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
@@ -32,7 +31,7 @@ public class SubCommandReload extends SubCommand {
 			SettingsManager.getConfig().save(uc.getFile());
 			SettingsManager.getConfig().load(uc.getFile());
 			SettingsManager.getConfig().loadConfiguration(uc.getFile());
-		} catch (IOException e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -6,8 +6,11 @@ import be.isach.ultracosmetics.command.SubCommand;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.ChatColor;
 
 public class SubCommandReload extends SubCommand {
+
+	private UltraCosmetics uc;
 
 	public SubCommandReload(UltraCosmetics ultraCosmetics) {
 		super("Reload the plugin and config.", "ultracosmetics.command.reload", "/uc reload", ultraCosmetics, "reload");
@@ -24,7 +27,18 @@ public class SubCommandReload extends SubCommand {
 	}
 
 	private void common(CommandSender sender, String... args) {
-		SettingsManager.getConfig().loadConfiguration(getUltraCosmetics().getFile());
-		sender.sendMessage(org.bukkit.ChatColor.GREEN + "Plugin has been loaded successfully.");
+		SettingsManager.getConfig().loadConfiguration(uc.getFile());
+
+		for (be.isach.ultracosmetics.player.UltraPlayer pl : uc.getPlayerManager().getUltraPlayers()) {
+			if (pl.getInventory().getTitle().equalsIgnoreCase(uc.getMenus().getMainMenu().getName())) {
+				pl.closeInventory();
+				//sender.sendMessage(ChatColor.RED + "The cosmetics menu has been closed, because reloading the plugin.");
+			}
+			uc.getPlayerManager().getUltraPlayer(pl).removeMenuItem();
+
+			uc.getPlayerManager().getUltraPlayer(pl).giveMenuItem();
+			uc.getPlayerManager().getUltraPlayer(pl).updateInventory();
+		}
+		sender.sendMessage(ChatColor.GREEN + "Plugin has been loaded successfully.");
 	}
 }

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -3,6 +3,7 @@ package be.isach.ultracosmetics.command.subcommands;
 import be.isach.ultracosmetics.config.SettingsManager;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.command.SubCommand;
+import java.io.IOException;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
@@ -27,9 +28,13 @@ public class SubCommandReload extends SubCommand {
 	}
 
 	private void common(CommandSender sender, String... args) {
-		SettingsManager.getConfig().save(uc.getFile());
-		SettingsManager.getConfig().load(uc.getFile());
-		SettingsManager.getConfig().loadConfiguration(uc.getFile());
+		try {
+			SettingsManager.getConfig().save(uc.getFile());
+			SettingsManager.getConfig().load(uc.getFile());
+			SettingsManager.getConfig().loadConfiguration(uc.getFile());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 
 		for (be.isach.ultracosmetics.player.UltraPlayer pl : uc.getPlayerManager().getUltraPlayers()) {
 			if (pl.getBukkitPlayer().getInventory().getTitle().equalsIgnoreCase(SettingsManager.getConfig().getString("Menu-Item.Displayname"))) {

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -1,0 +1,31 @@
+package be.isach.ultracosmetics.command.subcommands;
+
+import be.isach.ultracosmetics.UltraCosmetics;
+import be.isach.ultracosmetics.command.SubCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
+import org.bukkit.entity.Player;
+
+public class SubCommandClear extends SubCommand {
+
+	public SubCommandClear(UltraCosmetics ultraCosmetics) {
+		super("Reload the plugin and config.", "ultracosmetics.command.reload", "/uc reload", ultraCosmetics, "reload");
+	}
+
+	@Override
+	protected void onExePlayer(Player sender, String... args) {
+		common(sender, args);
+	}
+
+	@Override
+	protected void onExeConsole(ConsoleCommandSender sender, String... args) {
+		common(sender, args);
+	}
+
+	private void common(CommandSender sender, String... args) {
+		getUltraCosmetics().getConfig().loadConfiguration(getUltraCosmetics().getFile());
+		sender.sendMessage(ChatColor.GREEN + "Plugin has been loaded successfully.");
+	}
+}

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -7,9 +7,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
-public class SubCommandClear extends SubCommand {
+public class SubCommandReload extends SubCommand {
 
-	public SubCommandClear(UltraCosmetics ultraCosmetics) {
+	public SubCommandReload(UltraCosmetics ultraCosmetics) {
 		super("Reload the plugin and config.", "ultracosmetics.command.reload", "/uc reload", ultraCosmetics, "reload");
 	}
 

--- a/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
+++ b/core/src/main/java/be/isach/ultracosmetics/command/subcommands/SubCommandReload.java
@@ -1,9 +1,8 @@
 package be.isach.ultracosmetics.command.subcommands;
 
+import be.isach.ultracosmetics.config.SettingsManager;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.command.SubCommand;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
@@ -25,7 +24,7 @@ public class SubCommandClear extends SubCommand {
 	}
 
 	private void common(CommandSender sender, String... args) {
-		getUltraCosmetics().getConfig().loadConfiguration(getUltraCosmetics().getFile());
-		sender.sendMessage(ChatColor.GREEN + "Plugin has been loaded successfully.");
+		SettingsManager.getConfig().loadConfiguration(getUltraCosmetics().getFile());
+		sender.sendMessage(org.bukkit.ChatColor.GREEN + "Plugin has been loaded successfully.");
 	}
 }

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -36,6 +36,7 @@ permissions:
       - ultracosmetics.command.give.others
       - ultracosmetics.command.toggle.others
       - ultracosmetics.command.treasure
+      - ultracosmetics.command.reload
   ultracosmetics.command.clear:
     default: op
   ultracosmetics.command.toggle:
@@ -51,6 +52,8 @@ permissions:
   ultracosmetics.command.gadgets:
     default: op
   ultracosmetics.command.selfview:
+    default: op
+  ultracosmetics.command.reload:
     default: op
   ultracosmetics.gadgets.*:
     children: 


### PR DESCRIPTION
Its purpose is to reload at least the configuration so that it does not always have to stop and restart the server.

Shorten, adds the `/uc reload` command to reload the configuration (**only config.yml**).

#### Changes
- [x] Add reload command.
