### PR TITLE
Fixed EnderAura Particle

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectEnderAura.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectEnderAura.java
@@ -19,6 +19,6 @@ public class ParticleEffectEnderAura extends ParticleEffect {
 
 	@Override
 	public void onUpdate() {
-		getPlayer().getWorld().playEffect(getPlayer().getLocation().add(0, 1, 0), Effect.ENDER_SIGNAL, 0);
+                getPlayer().getWorld().spawnParticle(Particle.PORTAL, getPlayer().getLocation().add(0, 1, 0), 3, 0.2D, 0.01D, 0.2D);
 	}
 }

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectEnderAura.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectEnderAura.java
@@ -3,7 +3,7 @@ package be.isach.ultracosmetics.cosmetics.particleeffects;
 import be.isach.ultracosmetics.UltraCosmetics;
 import be.isach.ultracosmetics.cosmetics.type.ParticleEffectType;
 import be.isach.ultracosmetics.player.UltraPlayer;
-import org.bukkit.Effect;
+import be.isach.ultracosmetics.util.Particles;
 
 /**
  * Represents an instance of ender aura particles summoned by a player.

--- a/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectEnderAura.java
+++ b/core/src/main/java/be/isach/ultracosmetics/cosmetics/particleeffects/ParticleEffectEnderAura.java
@@ -19,6 +19,6 @@ public class ParticleEffectEnderAura extends ParticleEffect {
 
 	@Override
 	public void onUpdate() {
-                getPlayer().getWorld().spawnParticle(Particle.PORTAL, getPlayer().getLocation().add(0, 1, 0), 3, 0.2D, 0.01D, 0.2D);
+                Particles.PORTAL.display(0.2F, 0.01F, 0.02F, 0, 3, getPlayer().getLocation().add(0, 1, 0), 128);
 	}
 }


### PR DESCRIPTION
Adjusted the EnderAura particle from using the Effect type to spawning particles by using a different approach.

### What is the purpose of this pull request?
_Describe the problem or feature in addition to linking relevant issues._
The EnderAura particle is using the Effect type which has drastically changed across versions resulting in spam.

### How do your changes address the purpose?
_Describe what you did that addresses the purpose of this pull request._
These changes take a different approach to spawning the particle via the world to reduce the particle count and improve the effect.
