### PR TITLE
Fix null pointer exception PlayerListener#onInteract

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,6 +9,6 @@ dependencies {
         exclude group: 'org.bukkit'
     }
     compile 'me.clip:placeholderapi:2.10.3'
-    compile 'org.black_ixx:PlayerPoints:2.1.3'
+    compile 'org.black_ixx:PlayerPoints:2.1.9'
     compile 'com.google.code.gson:gson:2.2.4'
 }

--- a/core/src/main/java/be/isach/ultracosmetics/listeners/PlayerListener.java
+++ b/core/src/main/java/be/isach/ultracosmetics/listeners/PlayerListener.java
@@ -143,7 +143,7 @@ public class PlayerListener implements Listener {
                 && t != InventoryType.CREATIVE) {
             return;
         }
-        if (ultraPlayer.getCurrentTreasureChest() != null) {
+        if (ultraPlayer != null && ultraPlayer.getCurrentTreasureChest() != null) {
             event.setCancelled(true);
             return;
         }


### PR DESCRIPTION
### What is the purpose of this pull request?
Nullpointer exception is thrown when no player is returned from the UltraPlayer cache.

This fix issue #534.

### How do your changes address the purpose?
I added a null check before calling UltraPlayer#getCurrentTreasureChest()

#### Changes
- [x] Add null pointer
- [x] Upgraded PlayerPoints dependency to the latest version. New maintainers here: https://github.com/Rosewood-Development/PlayerPoints