### PR TITLE
Change default Permission Command to LP

### DIFF
--- a/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
+++ b/core/src/main/java/be/isach/ultracosmetics/UltraCosmetics.java
@@ -428,7 +428,7 @@ public class UltraCosmetics extends JavaPlugin {
             config.set(section + ".Message.enabled", false);
             config.set(section + ".Message.message", "%prefix% &6&l%name% found a flower!");
             config.set(section + ".Cancel-If-Permission", "example.yellowflower");
-            config.set(section + ".Commands", Arrays.asList("give %name% yellow_flower 1", "pex user %name% add example.yellowflower"));
+            config.set(section + ".Commands", Arrays.asList("give %name% yellow_flower 1", "lp user %name% permission set example.yellowflower true"));
         }
 
         config.addDefault("Categories.Clear-Cosmetic-Item", UCMaterial.REDSTONE_BLOCK.parseMaterial().toString(), "Item where user click to clear a cosmetic.");

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -57,7 +57,7 @@ Economy: 'Vault'
 # About Treasure Chests designs:
 # For a list of effect: http://pastebin.com/CVKkufck
 # For the chest-types: NORMAL or ENDER
-# Material syntax: The "item ID" from https://minecraftitemids.com/ without the "minecraft:" and in Full Caps! (e.g. minecraft:stone -> STONE)
+# Material syntax: The "item ID" from https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
 # You CAN make more designs just copy one, paste it and modify.
 # Not twice same name!
 #

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -57,7 +57,7 @@ Economy: 'Vault'
 # About Treasure Chests designs:
 # For a list of effect: http://pastebin.com/CVKkufck
 # For the chest-types: NORMAL or ENDER
-# Material syntax: 'id:data'
+# Material syntax: The "item ID" from https://minecraftitemids.com/ without the "minecraft:" and in Full Caps! (e.g. minecraft:stone -> STONE)
 # You CAN make more designs just copy one, paste it and modify.
 # Not twice same name!
 #
@@ -72,7 +72,7 @@ Economy: 'Vault'
 #
 # For permission command:
 # Change it to correspond to your Permissions plugin!
-# Default one is Pex's.
+# Default one is LuckPerms.
 #
 TreasureChests:
   Enabled: true
@@ -177,7 +177,7 @@ TreasureChests:
         Cancel-If-Permission: 'example.yellowflower'
         Commands:
           - 'give %name% yellow_flower 1'
-          - 'pex user %name% add example.yellowflower'
+          - 'lp user %name% permission set example.yellowflower true'
   Designs:
     Classic:
       center-block: SEA_LANTERN
@@ -203,7 +203,7 @@ TreasureChests:
       barriers: NETHER_BRICK_FENCE
       chest-type: NORMAL
       effect: SMOKE_NORMAL
-  Permission-Add-Command: pex user %name% add %permission%
+  Permission-Add-Command: lp user %name% permission set %permission% true
 
 # This option will fill the blank slots of inventories
 # with a custom item!

--- a/core/src/main/resources/treasurechests/rewards.yml
+++ b/core/src/main/resources/treasurechests/rewards.yml
@@ -20,7 +20,7 @@ reward-name:
     enabled: false
     permission: ranks.legend
   reward-commands:
-    - "pex user {player-uuid} set rank titan"
+    - "lp user {player-uuid} parent set titan"
   sound:
     enabled: true
     sound-effect: EXPLODE


### PR DESCRIPTION
This PR changes the default  Permission Command to LP as I think most people use LP instead of PEX (As PEX is very outdated/abandoned)
This is the current state which would then be changed: https://github.com/iSach/UltraCosmetics/wiki/Treasure-Chests#giving-permissions
This PR also adjusts the Material Syntax in config.yml to match the new behavior in UC-2.6-DEV-b9 (Using Materials instead of Legacy IDs)
