### PR TITLE
Use custom entity-registries if available

### DIFF
--- a/v1_18_R2/src/main/java/be/isach/ultracosmetics/v1_18_R2/customentities/CustomEntities.java
+++ b/v1_18_R2/src/main/java/be/isach/ultracosmetics/v1_18_R2/customentities/CustomEntities.java
@@ -1,5 +1,7 @@
 package be.isach.ultracosmetics.v1_18_R2.customentities;
 
+import be.isach.ultracosmetics.UltraCosmetics;
+import be.isach.ultracosmetics.UltraCosmeticsData;
 import com.mojang.datafixers.DataFixUtils;
 import com.mojang.datafixers.types.Type;
 
@@ -7,6 +9,7 @@ import be.isach.ultracosmetics.v1_18_R2.EntityBase;
 import be.isach.ultracosmetics.v1_18_R2.ObfuscatedFields;
 import be.isach.ultracosmetics.v1_18_R2.nms.EntityWrapper;
 import net.minecraft.SharedConstants;
+import net.minecraft.core.DefaultedRegistry;
 import net.minecraft.core.Holder;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.Registry;
@@ -50,9 +53,10 @@ public enum CustomEntities {
     private ResourceLocation minecraftKey;
     private Class<? extends Mob> nmsClass;
     private Class<? extends Entity> customClass;
+    private static DefaultedRegistry<EntityType<?>> entityRegistry;
 
     private CustomEntities(String name, int id, EntityType entityType, Class<? extends Mob> nmsClass,
-                   Class<? extends Entity> customClass) {
+                           Class<? extends Entity> customClass) {
         this.name = name;
         this.id = id;
         this.entityType = entityType;
@@ -64,12 +68,47 @@ public enum CustomEntities {
     public static void registerEntities() {
         Map<String, Type<?>> types = (Map<String, Type<?>>) DataFixers.getDataFixer().getSchema(DataFixUtils.makeKey(SharedConstants.getCurrentVersion().getWorldVersion())).findChoiceType(References.ENTITY).types();
 
+        // Get the current entityRegistry
+        entityRegistry = getRegistry(Registry.ENTITY_TYPE);
+
         unfreezeRegistry();
         registerEntity("zombie", Pumpling::new, types);
         registerEntity("slime", CustomSlime::new, types);
         registerEntity("spider", RideableSpider::new, types);
         registerEntity("guardian", CustomGuardian::new, types);
-        Registry.ENTITY_TYPE.freeze();
+        entityRegistry.freeze();
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public static DefaultedRegistry<EntityType<?>> getRegistry(DefaultedRegistry registryMaterials) {
+        /* We want to use custom entity-registries if there are any.
+            We therefore check if there is one and then look for the right registry.
+
+            This avoids problems with UltraCosmetics using the minecraft-registry whilst other
+            plugins are using the custom one which can lead to problems with one of the registries
+            being frozen and then blocking the other one from being edited.
+         */
+
+        if (!registryMaterials.getClass().getName().equals(DefaultedRegistry.class.getName())) {
+            UltraCosmeticsData.get().getPlugin().getSmartLogger().write("Custom entity registry found: " + registryMaterials.getClass().getName());
+            for (Field field : registryMaterials.getClass().getDeclaredFields()) {
+                if (field.getType() == MappedRegistry.class) {
+                    field.setAccessible(true);
+                    try {
+                        DefaultedRegistry<EntityType<?>> reg = (DefaultedRegistry<EntityType<?>>) field.get(registryMaterials);
+
+                        if (!reg.getClass().getName().equals(DefaultedRegistry.class.getName())) {
+                            reg = getRegistry(reg);
+                        }
+
+                        return reg;
+                    } catch (IllegalAccessException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        return registryMaterials;
     }
 
     private static void unfreezeRegistry() {
@@ -80,7 +119,7 @@ public enum CustomEntities {
            If frozen is true or "intrusiveHolderCache" is null, it will refuse to add entries,
            so we just have to fix both of those things and it'll let us add entries again.
            The registry being frozen may be vital to how the registry works (idk), so it is refrozen after adding our entries.
-           
+
            Partial stack trace produced when trying to add entities when the registry is frozen:
            [Server thread/ERROR]: Registry is already frozen initializing UltraCosmetics v2.6.1-DEV-b5 (Is it up to date?)
             java.lang.IllegalStateException: Registry is already frozen
@@ -93,21 +132,21 @@ public enum CustomEntities {
         try {
             Field intrusiveHolderCache = registryClass.getDeclaredField(ObfuscatedFields.INTRUSIVE_HOLDER_CACHE);
             intrusiveHolderCache.setAccessible(true);
-            intrusiveHolderCache.set(Registry.ENTITY_TYPE, new IdentityHashMap<EntityType<?>, Holder.Reference<EntityType<?>>>());
+            intrusiveHolderCache.set(entityRegistry, new IdentityHashMap<EntityType<?>, Holder.Reference<EntityType<?>>>());
             Field frozen = registryClass.getDeclaredField(ObfuscatedFields.FROZEN);
             frozen.setAccessible(true);
-            frozen.set(Registry.ENTITY_TYPE, false);
+            frozen.set(entityRegistry, false);
         } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
             e.printStackTrace();
             return;
         }
     }
-    
+
     private static void registerEntity(String type, EntityFactory customMob, Map<String,Type<?>> types) {
         String customName = "minecraft:ultracosmetics_" + type;
         types.put(customName, types.get("minecraft:" + type));
         EntityType.Builder<Entity> a = EntityType.Builder.of(customMob, MobCategory.AMBIENT);
-        Registry.register(Registry.ENTITY_TYPE, customName, a.build(customName));
+        Registry.register(entityRegistry, customName, a.build(customName));
     }
 
     public static void unregisterEntities() {}


### PR DESCRIPTION
### What is the purpose of this pull request?
Good old Entity-Registries am I right?  
So basically the new freezing and unfreezing would cause problems with other plugins also wanting to add custom entities as plugins like Citizens want other plugins to use their custom registries.  
A user of a plugin (MyPet) I maintain brought to my attention that if UltraCosmetics got enable before MyPet, MyPet wouldn't be able to unfreeze the registry anymore. There was no problem if UltraCosmetics got enabled AFTER MyPet.  
After some troubleshooting I noticed that the problem was that the plugins were accessing the entity-registry differently.  

### How do your changes address the purpose?
UC will now check if there is a custom registry provided by some other plugin and will then use said custom registry to do its thing.
This fix should have no effect on the functionality of the plugin.

#### Changes
- [x] Implemented method to get custom entities.